### PR TITLE
feat: add trip sequence flow

### DIFF
--- a/frontend/src/components/webtoon/TripSequence.js
+++ b/frontend/src/components/webtoon/TripSequence.js
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+
+function TripSequence({ spot, onComplete }) {
+  const frames = ['🚶‍♂️', '🏃‍♂️', '🏁'];
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setIndex(prev => {
+        if (prev < frames.length - 1) {
+          return prev + 1;
+        } else {
+          clearInterval(interval);
+          setTimeout(onComplete, 500);
+          return prev;
+        }
+      });
+    }, 700);
+
+    return () => clearInterval(interval);
+  }, [onComplete]);
+
+  return (
+    <div style={{
+      textAlign: 'center',
+      padding: '40px',
+      border: '3px solid #333',
+      borderRadius: '10px',
+      backgroundColor: '#f9f9f9',
+      maxWidth: '500px',
+      margin: '40px auto'
+    }}>
+      <div style={{ fontSize: '64px', marginBottom: '20px' }}>
+        {frames[index]}
+      </div>
+      <p style={{ fontSize: '18px', color: '#333' }}>{spot}로 이동 중...</p>
+    </div>
+  );
+}
+
+export default TripSequence;


### PR DESCRIPTION
## Summary
- detect recommended spots in chat responses and show travel options
- play a simple trip sequence before sending a follow-up message

## Testing
- `npm test -- --watchAll=false` *(fails: Unable to find an element with the text: /learn react/i)*

------
https://chatgpt.com/codex/tasks/task_e_68b08bfc37b4832a9e3d9fd76a9885da